### PR TITLE
Makes dynamic sizing of core-dropdown possible

### DIFF
--- a/core-dropdown.html
+++ b/core-dropdown.html
@@ -164,18 +164,24 @@ not scroll with its container.
       var target = this.target;
       // remember position, because core-overlay may have set the property
       var pos = target.style.position;
+      var width = target.style.width;
+      var height = target.style.height;
 
       // get the size of the target as if it's positioned in the top left
       // corner of the screen
       target.style.position = 'fixed';
       target.style.left = '0px';
       target.style.top = '0px';
+      target.style.width = null;
+      target.style.height = null;
 
       var rect = target.getBoundingClientRect();
 
       target.style.position = pos;
       target.style.left = null;
       target.style.top = null;
+      target.style.width = width;
+      target.style.height = height;
 
       return rect;
     },


### PR DESCRIPTION
Currently, the size of the dropdown is set in stone the first time the user views it. If the contents of the dropdown change in content or size later, the dropdown will not adjust. This is because measure() does not remove the width/height which is set from the results of measure() in previous runs, thus the size is always the "same".

In addition to this PR, I have pushed a fork of the current production tag (0.4.2) along with a patch onto:
https://github.com/rezonant/core-dropdown/tree/0.4.2_measurepatch. 

Reproduction
1. core-dropdown is opened
2. core-dropdown may be closed or left open
3. content changes, causing a new size
4. core-dropdown's overlay size is now incorrect until the widget is reloaded
