### PR TITLE
Allow closing a dropdown be prevented when certain elements are tapped

### DIFF
--- a/core-dropdown-base.html
+++ b/core-dropdown-base.html
@@ -41,6 +41,18 @@ should be a `core-dropdown` or other overlay element.
 
     },
 
+
+    /**
+	 * This specifies the name of the attribute that can be set on
+	 * elements within the dropdown to prevent them from closing the
+	 * dropdown on tap.
+     *
+     * @attribute dropdownKeepAttribute
+     * @type string
+     * @default 'core-dropdown-keep'
+     */
+    dropdownKeepAttribute: 'core-dropdown-keep',
+
     eventDelegates: {
       'tap': 'toggleOverlay'
     },
@@ -107,7 +119,13 @@ should be a `core-dropdown` or other overlay element.
       this.opened = !!e.detail;
     },
 
-    toggleOverlay: function() {
+    toggleOverlay: function(e) {
+      if (this.opened &&
+          this.dropdownKeepAttribute &&
+          e.target && e.target.hasAttribute(this.dropdownKeepAttribute))
+      {
+        return;
+      }
       this.opened = !this.opened;
     }
 

--- a/core-dropdown-base.html
+++ b/core-dropdown-base.html
@@ -43,9 +43,9 @@ should be a `core-dropdown` or other overlay element.
 
 
     /**
-	 * This specifies the name of the attribute that can be set on
-	 * elements within the dropdown to prevent them from closing the
-	 * dropdown on tap.
+     * This specifies the name of the attribute that can be set on
+     * elements within the dropdown to prevent them from closing the
+     * dropdown on tap.
      *
      * @attribute dropdownKeepAttribute
      * @type string


### PR DESCRIPTION
Hello all the Polymer people!

I think it would be a pretty useful feature to have the ability to prevent core-dropdown-base (and by extension, core-dropdown-menu and paper-dropdown-menu) from closing the overlay when certain elements are tapped. A good example would be a search form to filter the items provided in the dropdown.
I've come up with quite a simple way to do this by providing an attribute (core-dropdown-keep, though I'm not too sure that that's the best name) that you can set on an element in the overlay, which causes the toggleOverlay method to ignore it when it reacts to a tap.

Please let me know what you think about this.

Best regards,

Niels