### PR TITLE
Cleanup for older/pickier interpreters

### DIFF
--- a/core-dropdown.html
+++ b/core-dropdown.html
@@ -160,7 +160,7 @@ not scroll with its container.
        * @type String
        * @default 'top'
        */
-      valign: 'top',
+      valign: 'top'
 
     },
 
@@ -197,7 +197,7 @@ not scroll with its container.
       }
 
       var style = this.sizingTarget.style;
-      style.width = null
+      style.width = null;
       style.height = null;
       this.super();
     },


### PR DESCRIPTION
Sorry for the trivial pull request.  I know the extra trailing comma is ECMA5 compatible, but IntelliJ IDEA's interpreter was choking on it, and some older browsers might as well.

Noticed the missing semi-colon while I was in there.